### PR TITLE
Feature/remove rails config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ When using the wonderful ACF plugin, consider installing the `wp-api-acf` plugin
 
 In WordPress configure the "Webhooks" (provided by HookPress) from the admin backend. Make sure that it triggers webhook calls for all changes in the content that is to be served from the Rails app.  The Webhook action needs to send at least the `ID` and `Parent_ID` fields, other fields generally not needed.  Point the target URLs of the Webhooks to the `post_save` route in the Rails app.
 
-Add the wordpress json route to your rails configuration by adding the `wordpress_url` config option to your settings file in `config/settings` (e.g. `config/settings/development.yml`):
+Add the wordpress json route to your rails configuration by adding the `wordpress_url` config option to your environment file in `config/environments` (e.g.
+ `config/environments/development.rb`):
 ```ruby
-wordpress_url: "http://wpep.dev/?json_route="
+config.x.wordpress_url: "http://wpep.dev/?json_route="
 ```
 Here `wpep.dev` is the domain for your Wordpress site.
 
@@ -64,9 +65,9 @@ Create a `WpConnectorController` class (in `app/controllers/wp_connector_control
 ```ruby
 class WpConnectorController < ApplicationController
   include WpConnection
-  
+
   def post_save
-     Post.sync_cache('posts', wp_id_from_params) 
+     Post.sync_cache('posts', wp_id_from_params)
   end
 
   def post_delete
@@ -86,7 +87,7 @@ class Post < ActiveRecord::Base
     author_params = json["author"]
     author = Author.find_or_create(author_params["ID"])
     author.update_wp_cache(author_params)
-    
+
     self.id         = json["ID"]
     self.title      = json["title"]
     self.content    = json["content"]
@@ -136,7 +137,7 @@ class CreatePostsAndAuthors < ActiveRecord::Migration
       t.text    :excerpt
       t.timestamps
     end
-    
+
     create_table :authors do |t|
       t.string :username
       t.string :name

--- a/app/models/concerns/wp_cache.rb
+++ b/app/models/concerns/wp_cache.rb
@@ -16,7 +16,7 @@ module WpCache
     def sync_cache(wp_type, wp_id)
       WpGetWorker.perform_async(self, wp_type, wp_id)
     end
-  
+
     def purge_cache(wp_id)
       m = self.find(wp_id)
       if m
@@ -25,15 +25,15 @@ module WpCache
         logger.warn "Could not find #{self} with id #{wp_id}."
       end
     end
-    
+
     def retrieve_and_update_wp_cache(wp_type, wp_id)
-      response = Faraday.get "#{Settings.wordpress_url}/#{wp_type}/#{wp_id}"
+      response = Faraday.get "#{Rails.configuration.x.wordpress_url}/#{wp_type}/#{wp_id}"
       wp_json = JSON.parse(response.body)
       self.where(id: wp_id).first_or_create.update_wp_cache(wp_json)
     end
 
     def get_and_save_all(wpclass)
-      response = Faraday.get "#{Settings.wordpress_url}/#{wpclass.pluralize.downcase}"
+      response = Faraday.get "#{Rails.configuration.x.wordpress_url}/#{wpclass.pluralize.downcase}"
       wp_json = JSON.parse(response.body)
       ids = []
       wp_json.each do |json|
@@ -49,7 +49,7 @@ module WpCache
           end
         end
       end
-      
+
     end
   end
 end

--- a/wp-connector.gemspec
+++ b/wp-connector.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 1.9.2"
+
   spec.add_dependency "json"
   spec.add_dependency "faraday"
   spec.add_dependency "sidekiq"

--- a/wp-connector.gemspec
+++ b/wp-connector.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json"
   spec.add_dependency "faraday"
   spec.add_dependency "sidekiq"
-  spec.add_dependency "rails_config"
-  
+
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 end

--- a/wp-connector.gemspec
+++ b/wp-connector.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday"
   spec.add_dependency "sidekiq"
 
+  spec.add_runtime_dependency 'rails', '>= 4.0.0'
+
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
We're currently using a la Rails 4 custom configurations instead of RailsConfig.
Also added runtime dependancy to Rails > 4 and ruby > 1.9.2
