### PR TITLE
Demodulize wordpress type in case of namespaced Rails models

### DIFF
--- a/app/models/concerns/wp_post.rb
+++ b/app/models/concerns/wp_post.rb
@@ -25,7 +25,7 @@ module WpPost
     end
 
     def wp_type
-      self.to_s.underscore.pluralize
+      self.to_s.demodulize.underscore.pluralize
     end
   end
 end


### PR DESCRIPTION
This resolves the issue when having namespaced models in your Rails application:

``` Rails
module Namespace
  class MyWpPost
    include WpPost
  end
end
```

The `wp-connector` internals use the `wp_type` method in `WpPost` to resolve the URL for fetching from Wordpress. This results in `/namespace/my_wp_post/{id}` and that's not correct.

With `demodulize`, it's certain the namespacing will not interfere.
