### PR TITLE
Unscope all create or update queries

### DIFF
--- a/app/controllers/concerns/wp_preview_tools.rb
+++ b/app/controllers/concerns/wp_preview_tools.rb
@@ -5,6 +5,8 @@
 module WpPreviewTools
   extend ActiveSupport::Concern
 
+  THRESHOLD = 5
+
   #
   # Validates preview tokens for wp_post_models that are not published.
   # for instance the statuses `draft` and `pending`.
@@ -34,12 +36,15 @@ module WpPreviewTools
   # Retries loading of a WpCache model, if it was not found the first time.
   # This to avoid NotFound errors due to the delaying of WP API calls.
   #
-  def retry_when_preview(retrying = false, &block)
+  def retry_when_preview(retrying = false, threshold = 0, &block)
     raise "retry_when_preview requires a block" unless block_given?
     return block.call
   rescue ActiveRecord::ActiveRecordError => e
-    raise e if !params[:preview] || retrying
+    raise e unless params[:preview] || retrying
+    return nil if THRESHOLD < threshold
+
     sleep 1.5
-    return retry_when_preview(true, &block)
+
+    return retry_when_preview(true, threshold + 1, &block)
   end
 end

--- a/app/models/concerns/wp_cache.rb
+++ b/app/models/concerns/wp_cache.rb
@@ -41,7 +41,7 @@ module WpCache
       # WP API will return a code if the route is incorrect or
       # the specified entry is none existant. If so return early.
       return if wp_json[0] and invalid_api_responses.include? wp_json[0]["code"]
-      where(wp_id: wp_id).first_or_initialize.update_wp_cache(wp_json)
+      unscoped.where(wp_id: wp_id).first_or_initialize.update_wp_cache(wp_json)
     end
 
     def create_or_update_all
@@ -69,12 +69,12 @@ module WpCache
         break if wp_json.empty?
         ids << wp_json.map do |json|
           wp_id = json['ID']
-          where(wp_id: wp_id).first_or_initialize.update_wp_cache(json)
+          unscoped.where(wp_id: wp_id).first_or_initialize.update_wp_cache(json)
           wp_id
         end
         page = page + 1
       end
-      where('wp_id NOT IN (?)', ids.flatten).destroy_all unless ids.empty?
+      unscoped.where('wp_id NOT IN (?)', ids.flatten).destroy_all unless ids.empty?
     end
 
     # TODO (dunyakirkali) doc
@@ -82,17 +82,17 @@ module WpCache
       wp_json = get_from_wp_api(wp_type)
       ids = wp_json.map do |json|
         wp_id = json['ID']
-        where(wp_id: wp_id).first_or_initialize.update_wp_cache(json)
+        unscoped.where(wp_id: wp_id).first_or_initialize.update_wp_cache(json)
         wp_id
       end
-      where('wp_id NOT IN (?)', ids).destroy_all unless ids.empty?
+      unscoped.where('wp_id NOT IN (?)', ids).destroy_all unless ids.empty?
     end
 
     #
     # Purge a cached piece of content, while logging any exceptions.
     #
     def purge(wp_id)
-      where(wp_id: wp_id).first!.destroy
+      unscoped.where(wp_id: wp_id).first!.destroy
     rescue
       logger.warn "Could not purge #{self} with id #{wp_id}, no record with that id was found."
     end

--- a/app/models/concerns/wp_cache.rb
+++ b/app/models/concerns/wp_cache.rb
@@ -26,7 +26,7 @@ module WpCache
     # TODO (cies): add a configurable amount of delay, defaulting to 0.5secs
     def schedule_create_or_update(wp_id, preview = false, request = nil)
       extra_info = request ? " after #{request.fullpath} -- #{request.body.read}" : ""
-      Rails.logger.info("SCHEDULED by #{self.class}" + extra_info)
+      Rails.logger.info("SCHEDULED by #{self.name}" + extra_info)
       WpApiWorker.perform_async(self, wp_id, preview)
     end
 


### PR DESCRIPTION
We have a default scope on our model, which filters out non published posts. This resulted in WpCache.create_or_update trying to insert the same (unpublished) wp_id multiple times because `where(wp_id: wp_id)` didn't return this unpublished post. 
