### PR TITLE
Spawn sidekiq workers when updating options

### DIFF
--- a/app/models/concerns/wp_cache.rb
+++ b/app/models/concerns/wp_cache.rb
@@ -30,6 +30,10 @@ module WpCache
       WpApiWorker.perform_async(self, wp_id, preview)
     end
 
+    def schedule_update_options
+      WpApiWorker.perform_async(self)
+    end
+
     #
     # Gets the content from the WP API, finds-or-creates a record for it,
     # and passes it the content by the `update_wp_cache` instance method.
@@ -42,6 +46,14 @@ module WpCache
       # the specified entry is none existant. If so return early.
       return if wp_json[0] and invalid_api_responses.include? wp_json[0]["code"]
       where(wp_id: wp_id).first_or_initialize.update_wp_cache(wp_json)
+    end
+
+    def update_options
+      wp_json = get_from_wp_api "options"
+      # WP API will return a code if the route is incorrect or
+      # the specified entry is none existant. If so return early.
+      return if wp_json[0] and invalid_api_responses.include? wp_json[0]["code"]
+      self.update_wp_cache(wp_json)
     end
 
     def create_or_update_all

--- a/app/workers/wp_api_worker.rb
+++ b/app/workers/wp_api_worker.rb
@@ -8,9 +8,13 @@ require 'sidekiq'
 class WpApiWorker
   include Sidekiq::Worker
 
-  def perform(klass, wp_id, preview = false)
+  def perform(klass, wp_id = nil, preview = false)
     cklass = klass.constantize
-    cklass.create_or_update(cklass.wp_type, wp_id, preview)
+    if wp_id
+      cklass.create_or_update(cklass.wp_type, wp_id, preview)
+    else
+      cklass.update_options()
+    end
   rescue Exceptions::WpApiResponseError => e
     Rails.logger.warn ("[FAILED JOB] " + e.message)
   end


### PR DESCRIPTION
WordPress options are a little different than WP post types. This implementation allows for synchronising with WordPress options (ACF options).
